### PR TITLE
Cast values when using getValueFromConfigArray()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1] - 2024-06-18
+### Fixed
+* It tries to cast step config values based on their configured type when using `StepBuilder::getValueFromConfigArray()`.
+
 ## [2.3.0] - 2024-03-18
 ### Added
 * New config param type multi line string (`ConfigParam::multiLineString()` / `ConfigParamTypes::MultiLineString`).

--- a/src/ConfigParam.php
+++ b/src/ConfigParam.php
@@ -65,4 +65,19 @@ final class ConfigParam
             'description' => $this->description,
         ];
     }
+
+    public function castValue(mixed $value): mixed
+    {
+        if ($this->type === ConfigParamTypes::Bool) {
+            return is_bool($value) ? $value : (bool) $value;
+        } elseif ($this->type === ConfigParamTypes::Int) {
+            return is_int($value) ? $value : (int) $value;
+        } elseif ($this->type === ConfigParamTypes::Float) {
+            return is_float($value) ? $value : (float) $value;
+        } elseif ($this->type === ConfigParamTypes::String || $this->type === ConfigParamTypes::MultiLineString) {
+            return is_string($value) ? $value : (string) $value;
+        }
+
+        return $value; // @phpstan-ignore-line
+    }
 }

--- a/src/RequestTracker.php
+++ b/src/RequestTracker.php
@@ -41,7 +41,7 @@ final class RequestTracker
 
     public function trackHeadlessBrowserResponse(
         ?RequestInterface $request = null,
-        ?ResponseInterface $response = null
+        ?ResponseInterface $response = null,
     ): void {
         foreach ($this->onHeadlessBrowserResponse as $closure) {
             $closure->call($this, $request, $response);

--- a/src/StepBuilder.php
+++ b/src/StepBuilder.php
@@ -69,13 +69,30 @@ abstract class StepBuilder
     }
 
     /**
-     * @param mixed[] $configParams
+     * @param mixed[] $configDataArray
      */
-    protected function getValueFromConfigArray(string $key, array $configParams): mixed
+    protected function getValueFromConfigArray(string $key, array $configDataArray): mixed
     {
-        foreach ($configParams as $configParam) {
-            if ($configParam['name'] === $key) {
-                return $configParam['value'];
+        foreach ($configDataArray as $configDataProperty) {
+            if ($configDataProperty['name'] === $key) {
+                $configParam = $this->getConfigParam($key);
+
+                if ($configParam) {
+                    return $configParam->castValue($configDataProperty['value']);
+                }
+
+                return $configDataProperty['value'];
+            }
+        }
+
+        return null;
+    }
+
+    protected function getConfigParam(string $key): ?ConfigParam
+    {
+        foreach ($this->configParams() as $configParam) {
+            if ($configParam->name === $key) {
+                return $configParam;
             }
         }
 

--- a/tests/ExtensionPackageTest.php
+++ b/tests/ExtensionPackageTest.php
@@ -66,7 +66,7 @@ it(
         $anotherPackage = $manager->registerPackage('another-package');
 
         $anotherPackage->registerStep(DummyStep::class);
-    }
+    },
 )->throws(DuplicateStepIdException::class);
 
 test('getSteps() returns all steps registered for this package', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -22,7 +22,7 @@ uses()
     ->beforeEach(function () {
         if (!isset(TestServerProcess::$process)) {
             TestServerProcess::$process = Process::fromShellCommandline(
-                'php -S localhost:8000 ' . __DIR__ . '/_Integration/Server.php'
+                'php -S localhost:8000 ' . __DIR__ . '/_Integration/Server.php',
             );
 
             TestServerProcess::$process->start();

--- a/tests/RequestTrackerTest.php
+++ b/tests/RequestTrackerTest.php
@@ -49,7 +49,7 @@ it('calls the callback with the provided request and response objects for http r
                 ->toBeInstanceOf(ResponseInterface::class);
 
             $callbackCalled = true;
-        }
+        },
     );
 
     $tracker->trackHttpResponse($request, $response);
@@ -98,7 +98,7 @@ it('calls the callback with the provided request and response objects for headle
                 ->toBeInstanceOf(ResponseInterface::class);
 
             $callbackCalled = true;
-        }
+        },
     );
 
     $tracker->trackHeadlessBrowserResponse($request, $response);

--- a/tests/StepBuilderTest.php
+++ b/tests/StepBuilderTest.php
@@ -151,7 +151,7 @@ it('turns the config params into an array', function () {
 
                 ConfigParam::bool('someBool')
                     ->inputLabel('Input label for some bool')
-                    ->description('This is a boolean config param')
+                    ->description('This is a boolean config param'),
             ];
         }
     };

--- a/tests/_Integration/TrackingGuzzleClientTest.php
+++ b/tests/_Integration/TrackingGuzzleClientTest.php
@@ -14,7 +14,7 @@ it('tracks an HTTP response', function () {
     $tracker->onHttpResponse(
         function (?RequestInterface $request, ?ResponseInterface $response) use (&$trackedResponses) {
             $trackedResponses[] = $response;
-        }
+        },
     );
 
     expect($trackedResponses)->toHaveCount(0);
@@ -41,7 +41,7 @@ it('tracks an HTTP response also when it is a client error response (4xx)', func
     $tracker->onHttpResponse(
         function (?RequestInterface $request, ?ResponseInterface $response) use (&$trackedResponses) {
             $trackedResponses[] = $response;
-        }
+        },
     );
 
     expect($trackedResponses)->toHaveCount(0);
@@ -68,7 +68,7 @@ it('tracks an HTTP response also when it is a server error response (5xx)', func
     $tracker->onHttpResponse(
         function (?RequestInterface $request, ?ResponseInterface $response) use (&$trackedResponses) {
             $trackedResponses[] = $response;
-        }
+        },
     );
 
     expect($trackedResponses)->toHaveCount(0);


### PR DESCRIPTION
Try to cast step config values based on their configured type when using `StepBuilder::getValueFromConfigArray()`.